### PR TITLE
Corrigir erro em alteração tipo de documento para recebimento

### DIFF
--- a/src/rn/PenRelTipoDocMapRecebidoRN.php
+++ b/src/rn/PenRelTipoDocMapRecebidoRN.php
@@ -72,6 +72,24 @@ class PenRelTipoDocMapRecebidoRN extends InfraRN {
         }
     }
 
+
+    /**
+     * Consulta os mapeamentos de tipos de documentos para envio de processos pelo Barramento PEN para recebimento
+     *
+     * @param PenRelTipoDocMapRecebidoDTO $parObjPenRelTipoDocMapRecebidoDTO
+     * @return void
+     */
+    protected function consultarConectado(PenRelTipoDocMapRecebidoDTO $parObjPenRelTipoDocMapRecebidoDTO)
+    {
+        try {
+            $objPenRelTipoDocMapRecebidoBD = new PenRelTipoDocMapEnviadoBD($this->getObjInfraIBanco());
+            return $objPenRelTipoDocMapRecebidoBD->consultar($parObjPenRelTipoDocMapRecebidoDTO);
+        }catch(Exception $e){
+            throw new InfraException('Erro consultando mapeamento de documentos para recebimento.',$e);
+        }
+    }
+
+
     /**
      * Remove uma espécie documental da base de dados do SEI baseado em um código de espécie do Barramento
      *


### PR DESCRIPTION
Correção e testes da funcionalidade de alteração do mapeamento de tipos de documentos para recebimento
de processos no SEI. Erro ocorria devido a falta da função de consulta de mapeamentos.

Closes: #5