### PR TITLE
Verificação do parâmetro de filtro de unidades para recebimento

### DIFF
--- a/src/rn/ProcessoEletronicoRN.php
+++ b/src/rn/ProcessoEletronicoRN.php
@@ -351,6 +351,11 @@ class ProcessoEletronicoRN extends InfraRN
         }
     }
 
+    /**
+     * Serviço responsável por pesquisar a listas de estruturas do Barramento de Serviços do PEN baseado nos critérios de pesquisa
+     * informados pelo usuário.
+     *
+     */
     public function listarEstruturas($idRepositorioEstrutura, $nome='', $numeroDeIdentificacaoDaEstruturaRaizDaConsulta = null,
         $nomeUnidade=null, $siglaUnidade=null, $offset=null, $registrosPorPagina=null, $parBolPermiteRecebimento=null, $parBolPermiteEnvio=null)
     {
@@ -392,11 +397,11 @@ class ProcessoEletronicoRN extends InfraRN
                 $parametros->filtroDeEstruturas->paginacao->quantidadeDeRegistros = $registrosPorPagina;
             }
 
-            if(!is_null($parBolPermiteRecebimento) && $parBolPermiteRecebimento === true){
+            if($parBolPermiteRecebimento === true){
                 $parametros->filtroDeEstruturas->permiteRecebimento = true;
             }
 
-            if(!is_null($parBolPermiteEnvio) && $parBolPermiteEnvio === true){
+            if($parBolPermiteEnvio === true){
                 $parametros->filtroDeEstruturas->permiteEnvio = true;
             }
 


### PR DESCRIPTION
Alteração do método de listagem de estruturas organizacionais para simplificar a validação de preenchimento do parâmetro de filtro de unidades para recebimento. 

Também foi adicionado o PHPDoc no método.