### PR TITLE
Correção de erro ao tentar excluir mapeamento de tipos de documentos para envio

### DIFF
--- a/src/rn/PenRelTipoDocMapEnviadoRN.php
+++ b/src/rn/PenRelTipoDocMapEnviadoRN.php
@@ -110,7 +110,9 @@ class PenRelTipoDocMapEnviadoRN extends InfraRN
             SessaoSEI::getInstance()->validarAuditarPermissao('pen_map_tipo_documento_envio_excluir', __METHOD__, $parArrObjPenRelTipoDocMapEnviadoDTO);
             $objPenRelTipoDocMapEnviadoBD = new PenRelTipoDocMapEnviadoBD($this->getObjInfraIBanco());
 
-            foreach ($parArrObjPenRelTipoDocMapEnviadoDTO as $objPenRelTipoDocMapEnviadoDTO) {
+            foreach ($parArrObjPenRelTipoDocMapEnviadoDTO as $IdMap) {
+                $objPenRelTipoDocMapEnviadoDTO = new PenRelTipoDocMapEnviadoDTO();
+                $objPenRelTipoDocMapEnviadoDTO->setDblIdMap($IdMap);
                 $objPenRelTipoDocMapEnviadoBD->excluir($objPenRelTipoDocMapEnviadoDTO);
             }
         }catch(Exception $e){


### PR DESCRIPTION
Correção de erro ao tentar excluir tipo de documento mapeado.