### PR TITLE
Ajustes para considerar o php.ini do escopo do servidor Web

### DIFF
--- a/src/pen_parametros_configuracao.php
+++ b/src/pen_parametros_configuracao.php
@@ -46,6 +46,33 @@ try {
     if ($objPenParametroDTO===null){
         throw new InfraException("Registros não encontrados.");
     }
+    
+    $objPenParametroRN = new PenParametroRN();
+    $objPenParametroDTO=new PenParametroDTO();
+    $objPenParametroDTO->setStrNome("PHP_INI_WEB");
+    $objPenParametroDTO->retStrValor();
+    $phpIniWeb=$objPenParametroRN->consultar($objPenParametroDTO);
+    $phpIniWeb=$phpIniWeb==null? null : $phpIniWeb->getStrValor();
+    
+    if($phpIniWeb==null){
+        $phpIniWeb=php_ini_loaded_file();
+        $objPenParametroDTO = new PenParametroDTO();
+        $objPenParametroDTO->setStrNome("PHP_INI_WEB");
+        $objPenParametroDTO->setStrValor($phpIniWeb);
+        $objPenParametroDTO->setStrDescricao("php.ini utilizado pelo servidor web do órgao");
+        $objPenParametroRN = new PenParametroRN();
+        $objPenParametroRN->cadastrar($objPenParametroDTO);
+
+    }elseif($phpIniWeb!=php_ini_loaded_file()){
+
+        $objPenParametroDTO = new PenParametroDTO();
+        $objPenParametroDTO->setStrNome("PHP_INI_WEB");
+        $objPenParametroDTO->setStrValor(php_ini_loaded_file());
+        $objPenParametroDTO->setStrDescricao("php.ini utilizado pelo servidor web do órgao");
+        $objPenParametroRN = new PenParametroRN();
+        $objPenParametroRN->alterar($objPenParametroDTO);
+    }
+
 
     switch ($_GET['acao']) {
         case 'pen_parametros_configuracao_salvar':
@@ -211,8 +238,15 @@ $objPagina->abrirBody($strTitulo, 'onload="inicializar();"');
 
         echo '</div>';
     }
-    ?>
+
+?>
 </form>
+
+    <label id="lblPhpIni" for="phpIniWeb" class="infraLabelObrigatorio">Caminho do php.ini utilizado (apenas para consulta):</label><br> 
+    <?php
+    echo '<input type="text" id="phpIniWeb" name="phpIniWeb" class="infraText infraReadOnly " value="'.$phpIniWeb .'" readonly />';
+    
+    ?>
 
 <?
 $objPagina->fecharBody();

--- a/src/rn/PendenciasTramiteRN.php
+++ b/src/rn/PendenciasTramiteRN.php
@@ -15,7 +15,7 @@ class PendenciasTramiteRN extends InfraRN
     const MAXIMO_PROCESSOS_MONITORAMENTO = 20;
     const COMANDO_IDENTIFICACAO_WORKER = "ps -c ax | grep 'MonitoramentoTarefasPEN\.php' | grep -o '^[ ]*[0-9]*'";
     const COMANDO_IDENTIFICACAO_WORKER_ID = "ps -c ax | grep 'MonitoramentoTarefasPEN\.php.*--worker=%02d' | grep -o '^[ ]*[0-9]*'";
-    const COMANDO_EXECUCAO_WORKER = 'nohup /usr/bin/php %s %s %s %s %s %s > /dev/null 2>&1 &';
+    const COMANDO_EXECUCAO_WORKER = 'nohup /usr/bin/php -c %s %s %s %s %s %s %s > /dev/null 2>&1 &';
     const LOCALIZACAO_SCRIPT_WORKER = DIR_SEI_WEB . "/../scripts/mod-pen/MonitoramentoTarefasPEN.php";
 
     private $objPenDebug = null;
@@ -480,6 +480,20 @@ class PendenciasTramiteRN extends InfraRN
         $parNumQtdeWorkers = min($parNumQtdeWorkers ?: self::NUMERO_PROCESSOS_MONITORAMENTO, self::MAXIMO_PROCESSOS_MONITORAMENTO);
 
         try {
+
+            $objPenParametroDTO=new PenParametroDTO();
+            $objPenParametroDTO->setStrNome("PHP_INI_WEB");
+            $objPenParametroDTO->retStrValor();
+            $objPenParametroRN = new PenParametroRN();
+            $phpIniWeb=$objPenParametroRN->consultar($objPenParametroDTO);
+            
+            if($phpIniWeb==null){
+                throw new Exception("O php.ini não foi configurado ainda no PenParametros, favor acessar a página "
+                 ." de parâmetros do Pen (Administração>Processo Eletrônico Nacional>Parâmetros de Configuração) que a persistência do caminho do php.ini será feita automaticamente em background."); 
+            }else{
+                $phpIniWeb=$phpIniWeb->getStrValor();
+            }
+
             for ($worker=0; $worker < $parNumQtdeWorkers; $worker++) {
                 $strComandoIdentificacaoWorker = sprintf(self::COMANDO_IDENTIFICACAO_WORKER_ID, $worker);
                 exec($strComandoIdentificacaoWorker, $strSaida, $numCodigoResposta);
@@ -494,7 +508,7 @@ class PendenciasTramiteRN extends InfraRN
 
                     $strParametroWsdlCache = "--wsdl-cache='$strWsdlCacheDir'";
                     $strComandoInicializacao = sprintf(
-                        self::COMANDO_EXECUCAO_WORKER, $strLocalizacaoScript, $strIdWorker,
+                        self::COMANDO_EXECUCAO_WORKER, $phpIniWeb, $strLocalizacaoScript, $strIdWorker,
                         $strParametroMonitorar, $strParametroSegundoPlano, $strParametroDebugAtivo, $strParametroWsdlCache
                     );
 
@@ -515,9 +529,11 @@ class PendenciasTramiteRN extends InfraRN
             $bolInicializado = $numCodigoRespostaAtivacao == 0;
 
         } catch (\Exception $e) {
-            $strMensagem = "Falha: Não foi possível iniciar o monitoramento de tarefas Barramento PEN";
+            $strMensagem = "Falha: Não foi possível iniciar o monitoramento de tarefas Barramento PEN. ";
             $objInfraException = new InfraException($strMensagem, $e);
             LogSEI::getInstance()->gravar(InfraException::inspecionar($objInfraException), LogSEI::$ERRO);
+            //forçar a falha do agendamento, devemos lançar outra Exceção, caso contrário aparece como "Sucesso" e apenas grava em log
+            throw new InfraException($strMensagem . $e->getMessage());
         }
 
         return $bolInicializado;

--- a/src/scripts/MonitoramentoTarefasPEN.php
+++ b/src/scripts/MonitoramentoTarefasPEN.php
@@ -8,6 +8,8 @@ if ($argv && $argv[0] && realpath($argv[0]) === __FILE__) {
 
     ini_set('max_execution_time','0');
     ini_set('memory_limit','-1');
+    ini_set("log_errors", 1);
+    ini_set("error_log", "/root/infra_agendamento_sei.log");
 
     InfraDebug::getInstance()->setBolLigado(true);
     InfraDebug::getInstance()->setBolDebugInfra(false);


### PR DESCRIPTION
Na página de parâmetros do PEN, em background, será gravado o php.ini do escopo do servidor web. Assim nas chamadas dos agendamentos este será recuperado no BD.Foram inseridos logs e mensagens de erros para os casos de não configuração do php.ini.Por fim, foi incluido o error_log no MonitoramentoTarefasPEN pois em casos de Fatal Error não existiam logs.