### PR TITLE
Ajustes para considerar o php.ini correto na inicialização de processo de recebimento

### DIFF
--- a/src/rn/PenRelTipoDocMapEnviadoRN.php
+++ b/src/rn/PenRelTipoDocMapEnviadoRN.php
@@ -110,7 +110,9 @@ class PenRelTipoDocMapEnviadoRN extends InfraRN
             SessaoSEI::getInstance()->validarAuditarPermissao('pen_map_tipo_documento_envio_excluir', __METHOD__, $parArrObjPenRelTipoDocMapEnviadoDTO);
             $objPenRelTipoDocMapEnviadoBD = new PenRelTipoDocMapEnviadoBD($this->getObjInfraIBanco());
 
-            foreach ($parArrObjPenRelTipoDocMapEnviadoDTO as $objPenRelTipoDocMapEnviadoDTO) {
+            foreach ($parArrObjPenRelTipoDocMapEnviadoDTO as $IdMap) {
+                $objPenRelTipoDocMapEnviadoDTO = new PenRelTipoDocMapEnviadoDTO();
+                $objPenRelTipoDocMapEnviadoDTO->setDblIdMap($IdMap);
                 $objPenRelTipoDocMapEnviadoBD->excluir($objPenRelTipoDocMapEnviadoDTO);
             }
         }catch(Exception $e){


### PR DESCRIPTION
Implementado ajuste na rotina de recebimento de pendências do Barramento de Serviços do PEN para iniciar o script paralelo de recebimento utilizando a configuração correta do php.ini definida no contexto da execução, seja ela pela web ou pelo crontab.
    
Closes #51
