### PR TITLE
Correção de erro em todo sistema por falta de configuração do módulo

### DIFF
--- a/src/PENIntegracao.php
+++ b/src/PENIntegracao.php
@@ -34,18 +34,13 @@ class PENIntegracao extends SeiIntegracao
 
     public function inicializar($strVersaoSEI)
     {
-        $strDirSEIWeb = realpath(DIR_SEI_CONFIG.'/../web');
-        define('DIR_SEI_WEB', $strDirSEIWeb);
+        define('DIR_SEI_WEB', realpath(DIR_SEI_CONFIG.'/../web'));
 
-        $strArquivoConfiguracaoModulo = DIR_SEI_CONFIG . '/mod-pen/ConfiguracaoModPEN.php';
-        if(!file_exists($strArquivoConfiguracaoModulo)){
-            throw new InfraException("Arquivo de configuração do módulo '{$this->getNome()}' não pode ser localizado em '$strArquivoConfiguracaoModulo'");
-        }
-
-        include_once $strArquivoConfiguracaoModulo;
-
-        PENIntegracao::validarCompatibilidadeModulo($strVersaoSEI);
+        // Aplicação de validações pertinentes à instalação e inicialização do módulo
+        // Regras de verificação da disponibilidade do PEN não devem ser aplicadas neste ponto pelo risco de erro geral no sistema em
+        // caso de indisponibilidade momentânea do Barramento de Serviços.
         PENIntegracao::validarArquivoConfiguracao();
+        PENIntegracao::validarCompatibilidadeModulo($strVersaoSEI);
     }
 
 

--- a/src/pen_parametros_configuracao.php
+++ b/src/pen_parametros_configuracao.php
@@ -178,7 +178,7 @@ $objPagina->abrirBody($strTitulo, 'onload="inicializar();"');
                     echo '</select>';
                 } catch (Exception $e) {
                     // Caso ocorra alguma falha na obtenção de dados dos serviços do PEN, apresenta estilo de campo padrão
-                    echo '<input type="text" id="PARAMETRO_PEN_ID_REPOSITORIO_ORIGEM" name="parametro[PEN_ID_REPOSITORIO_ORIGEM]" class="infraText input-field load_error" value="'.$objPagina->tratarHTML($parametro->getStrValor()).'" onkeypress="return infraMascaraTexto(this,event);" tabindex="'.$objPagina->getProxTabDados().'" maxlength="100" />';
+                    echo '<input type="text" id="PEN_ID_REPOSITORIO_ORIGEM" name="parametro[PEN_ID_REPOSITORIO_ORIGEM]" class="infraText input-field load_error" value="'.$objPagina->tratarHTML($parametro->getStrValor()).'" onkeypress="return infraMascaraTexto(this,event);" tabindex="'.$objPagina->getProxTabDados().'" maxlength="100" />';
                     echo '<img class="erro_pen" src="imagens/sei_erro.png" title="Não foi possível carregar os Repositórios de Estruturas disponíveis no PEN devido à falha de acesso ao Barramento de Serviços. O valor apresentação no campo é o código do repositório configurado anteriormente">';
                 }
 


### PR DESCRIPTION
Falha provocada em diversos pontos do sistema por falta de determinadas configurações por parte do módulo. Modificado comportamento para validar apenas aqueles parâmetros básicas da instalação do módulo, deixando os demais para ser validado somente quando funcionalidades do módulo forem acionadas.

Closes #53