### PR TITLE
Ajuste para apenas validar os casos que documento é cancelado

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,12 @@ clean:
 install: 
 	unzip -o -d $(SEI_PATH) dist/$(PEN_MODULO_COMPACTADO)
 
+install-dev: 
+	ln -sf $(PWD)/src/bin $(SEI_PATH)/sei/bin/mod-pen
+	ln -sf $(PWD)/src/config $(SEI_PATH)/sei/config/mod-pen
+	ln -sf $(PWD)/src/scripts $(SEI_PATH)/sei/scripts/mod-pen
+	ln -sf $(PWD)/src/ $(SEI_PATH)/sei/web/modulos/pen
+	
 
 test-environment-provision:	
 	export HOST_IP=$(HOST_IP); docker-compose -f $(PEN_TEST_FUNC)/docker-compose.yml --env-file $(PEN_TEST_FUNC)/.env up -d	
@@ -93,7 +99,7 @@ test-environment-down:
 
 
 test-functional:
-	$(PEN_TEST_FUNC)/vendor/phpunit/phpunit/phpunit -c $(PEN_TEST_FUNC)/phpunit.xml --testsuite funcional
+	$(PEN_TEST_FUNC)/vendor/phpunit/phpunit/phpunit -c $(PEN_TEST_FUNC)/phpunit.xml --stop-on-failure  --testsuite funcional
 
 
 test-functional-parallel:

--- a/docs/changelogs/CHANGELOG-2.1.4.md
+++ b/docs/changelogs/CHANGELOG-2.1.4.md
@@ -1,0 +1,19 @@
+# NOTAS DE VERSÃO MOD-SEI-PEN (versão 2.1.4)
+
+Este documento descreve as principais mudanças aplicadas nesta versão do módulo de integração do SEI com o Barramento de Serviços do PEN. 
+
+As melhorias entregues em cada uma das versões são cumulativas, ou seja, contêm todas as implementações realizada em versões anteriores.
+
+Para maiores informações sobre os procedimentos de instalação ou atualização, acesse os seguintes documentos localizados no pacote de distribuição mod-sei-pen-VERSAO.zip:
+
+* **INSTALACAO.md** - Procedimento de instalação e configuração do módulo
+* **ATUALIZACAO.md** - Procedimento específicos para atualização de uma versão anterior
+
+
+## Lista de Melhorias e Correções de Problemas
+
+
+#### Issue #57 - Adequação do módulo para a versão 3.1.6 do SEI
+
+Adequação e homologação do correto funcionamento do módulo de integração com o
+Barramento de Serviços do PEN com a versão 3.1.6 do SEI

--- a/src/PENIntegracao.php
+++ b/src/PENIntegracao.php
@@ -2,7 +2,7 @@
 
 class PENIntegracao extends SeiIntegracao
 {
-    const VERSAO_MODULO = "2.1.3";
+    const VERSAO_MODULO = "2.1.4";
     const PARAMETRO_VERSAO_MODULO_ANTIGO = 'PEN_VERSAO_MODULO_SEI';
     const PARAMETRO_VERSAO_MODULO = 'VERSAO_MODULO_PEN';
 

--- a/src/rn/ReceberProcedimentoRN.php
+++ b/src/rn/ReceberProcedimentoRN.php
@@ -685,7 +685,7 @@ class ReceberProcedimentoRN extends InfraRN
 
         //Não valida informações do componente digital caso o documento esteja cancelado
         foreach($arrObjDocumentos as $objDocumento) {
-            if(isset($objDocumento->retirado) && $objDocumento->retirado === true){
+            if(!isset($objDocumento->retirado) || $objDocumento->retirado === false){
                 if (is_null($objDocumento->componenteDigital->tamanhoEmBytes) || $objDocumento->componenteDigital->tamanhoEmBytes == 0){
                     throw new InfraException('Tamanho de componente digital não informado.', null, 'RECUSA: '.ProcessoEletronicoRN::MTV_RCSR_TRAM_CD_OUTROU);
                 }

--- a/src/rn/VerificadorInstalacaoRN.php
+++ b/src/rn/VerificadorInstalacaoRN.php
@@ -30,7 +30,7 @@ require_once DIR_SEI_WEB . '/SEI.php';
 class VerificadorInstalacaoRN extends InfraRN
 {
     // A partir da versão 2.0.0, o módulo de integração do SEI com o PEN não será mais compatível com o SEI 3.0.X
-    const COMPATIBILIDADE_MODULO_SEI = array('3.1.0', '3.1.1', '3.1.2', '3.1.3', '3.1.4', '3.1.5');
+    const COMPATIBILIDADE_MODULO_SEI = array('3.1.0', '3.1.1', '3.1.2', '3.1.3', '3.1.4', '3.1.5', '3.1.6');
 
     public function __construct() {
         parent::__construct();

--- a/src/scripts/sei_atualizar_versao_modulo_pen.php
+++ b/src/scripts/sei_atualizar_versao_modulo_pen.php
@@ -97,6 +97,7 @@ class PenAtualizarSeiRN extends PenAtualizadorRN {
                 case '2.1.0': $this->instalarV2101();
                 case '2.1.1': $this->instalarV2102();
                 case '2.1.2': $this->instalarV2103();
+                case '2.1.3': $this->instalarV2104();
                     break;
                 default:
                 $this->finalizar('VERSAO DO MÓDULO JÁ CONSTA COMO ATUALIZADA');
@@ -2078,6 +2079,11 @@ class PenAtualizarSeiRN extends PenAtualizadorRN {
     protected function instalarV2103()
     {
         $this->atualizarNumeroVersao("2.1.3");
+    }
+
+    protected function instalarV2104()
+    {
+        $this->atualizarNumeroVersao("2.1.4");
     }
 }
 

--- a/src/scripts/sip_atualizar_versao_modulo_pen.php
+++ b/src/scripts/sip_atualizar_versao_modulo_pen.php
@@ -127,6 +127,7 @@ class PenAtualizarSipRN extends InfraRN {
                 case '2.1.0': $this->instalarV2101();
                 case '2.1.1': $this->instalarV2102();
                 case '2.1.2': $this->instalarV2103();
+                case '2.1.3': $this->instalarV2104();
                     break;
 
                 default:
@@ -1357,6 +1358,14 @@ class PenAtualizarSipRN extends InfraRN {
     protected function instalarV2103()
     {
 	    $this->atualizarNumeroVersao("2.1.3");
+    }
+
+    /**
+     * Instala/Atualiza os módulo PEN para versão 2.1.4
+     */
+    protected function instalarV2104()
+    {
+	    $this->atualizarNumeroVersao("2.1.4");
     }
 }
 


### PR DESCRIPTION
O módulo estava validando casos em que o anexo não existia, ocorrendo erro e recusa.