### PR TITLE
Substitui por vazio o nome do ógão superior quando não há hierarquia

### DIFF
--- a/src/int/ProcessoEletronicoINT.php
+++ b/src/int/ProcessoEletronicoINT.php
@@ -60,4 +60,45 @@ class ProcessoEletronicoINT extends InfraINT {
         $objExpedirProcedimentoRN = new ExpedirProcedimentoRN();
         return $objExpedirProcedimentoRN->listarProcessosApensados($dblIdProcedimentoAtual, $numIdUnidadeAtual, $strPalavrasPesquisa);
     }
+
+
+    public static function formatarHierarquia($ObjEstrutura)
+    {
+        $nome = "";
+
+        if(isset($ObjEstrutura->hierarquia)) {
+            
+            $arrObjNivel = $ObjEstrutura->hierarquia->nivel;
+
+            $siglasUnidades = array();
+            $siglasUnidades[] = $ObjEstrutura->sigla;
+
+            foreach($arrObjNivel as $key => $objNivel){
+                $siglasUnidades[] = $objNivel->sigla  ;
+            }
+
+            for($i = 1; $i <= 3; $i++){
+                if(isset($siglasUnidades[count($siglasUnidades) - 1])){
+                    unset($siglasUnidades[count($siglasUnidades) - 1]);
+                }
+            }
+
+            foreach($siglasUnidades as $key => $nomeUnidade){
+                if($key == (count($siglasUnidades) - 1)){
+                    $nome .= $nomeUnidade." ";
+                }else{
+                    $nome .= $nomeUnidade." / ";
+                }
+            }
+
+            $objNivel=current($arrObjNivel);
+
+        }
+        $dados=["nome"=>$nome,"objNivel"=>$objNivel];
+
+        return $dados;
+
+    }
+
+    
 }

--- a/src/rn/ExpedirProcedimentoRN.php
+++ b/src/rn/ExpedirProcedimentoRN.php
@@ -615,40 +615,16 @@ class ExpedirProcedimentoRN extends InfraRN {
             $objExpedirProcedimentoDTO->getNumIdRepositorioDestino(), $objExpedirProcedimentoDTO->getNumIdUnidadeDestino(), true
         );
 
-        if (isset($objEstrutura->hierarquia)) {
-
-            $arrObjNivel = $objEstrutura->hierarquia->nivel;
-
-            $nome = "";
-            $siglasUnidades = array();
-            $siglasUnidades[] = $objEstrutura->sigla;
-
-            foreach ($arrObjNivel as $key => $objNivel) {
-                $siglasUnidades[] = $objNivel->sigla;
-            }
-
-            for ($i = 1; $i <= 3; $i++) {
-                if (isset($siglasUnidades[count($siglasUnidades) - 1])) {
-                    unset($siglasUnidades[count($siglasUnidades) - 1]);
-                }
-            }
-
-            foreach ($siglasUnidades as $key => $nomeUnidade) {
-                if ($key == (count($siglasUnidades) - 1)) {
-                    $nome .= $nomeUnidade . " ";
-                } else {
-                    $nome .= $nomeUnidade . " / ";
-                }
-            }
-
-            $objNivel = current($arrObjNivel);
+            $dados=ProcessoEletronicoINT::formatarHierarquia($objEstrutura);
+            $nome=$dados['nome'];
+            $objNivel=$dados['objNivel'];
 
             $objAtributoAndamentoDTO = new AtributoAndamentoDTO();
             $objAtributoAndamentoDTO->setStrNome('UNIDADE_DESTINO_HIRARQUIA');
             $objAtributoAndamentoDTO->setStrValor($nome);
             $objAtributoAndamentoDTO->setStrIdOrigem($objNivel->numeroDeIdentificacaoDaEstrutura);
             $arrObjAtributoAndamentoDTO[] = $objAtributoAndamentoDTO;
-        }
+        
 
         //Seta a unidade de destino
         $arrUnidadeDestino = preg_split('/\s?\/\s?/', $objExpedirProcedimentoDTO->getStrUnidadeDestino());

--- a/src/rn/ProcessoEletronicoRN.php
+++ b/src/rn/ProcessoEletronicoRN.php
@@ -1972,6 +1972,7 @@ class ProcessoEletronicoRN extends InfraRN
             $strUltimaPalavra = $arrStrTokens[count($arrStrTokens) - 1];
 
             $numTamanhoUltimaPalavra = strlen($strUltimaPalavra) > $numTamanhoMaximoPalavra ? strlen($strReticencias) : strlen($strUltimaPalavra);
+            $numTamanhoUltimaPalavra = $numTamanhoUltimaPalavra < strlen($strReticencias) ? strlen($strReticencias) : $numTamanhoUltimaPalavra;
             $strTexto = substr($strTexto, 0, strlen($strTexto) - $numTamanhoUltimaPalavra);
             $strTexto = trim($strTexto) . $strReticencias;
         }

--- a/src/rn/ReceberProcedimentoRN.php
+++ b/src/rn/ReceberProcedimentoRN.php
@@ -1224,39 +1224,16 @@ class ReceberProcedimentoRN extends InfraRN
             $arrObjAtributoAndamentoDTO[] = $objAtributoAndamentoDTO;
         }
 
-        if(isset($objEstrutura->hierarquia)) {
-            $arrObjNivel = $objEstrutura->hierarquia->nivel;
-
-            $nome = "";
-            $siglasUnidades = array();
-            $siglasUnidades[] = $objEstrutura->sigla;
-
-            foreach($arrObjNivel as $key => $objNivel){
-                $siglasUnidades[] = $objNivel->sigla  ;
-            }
-
-            for($i = 1; $i <= 3; $i++){
-                if(isset($siglasUnidades[count($siglasUnidades) - 1])){
-                    unset($siglasUnidades[count($siglasUnidades) - 1]);
-                }
-            }
-
-            foreach($siglasUnidades as $key => $nomeUnidade){
-                if($key == (count($siglasUnidades) - 1)){
-                    $nome .= $nomeUnidade." ";
-                }else{
-                    $nome .= $nomeUnidade." / ";
-                }
-            }
-
-            $objNivel = current($arrObjNivel);
+            $dados=ProcessoEletronicoINT::formatarHierarquia($objEstrutura);
+            $nome=$dados['nome'];
+            $objNivel=$dados['objNivel'];
 
             $objAtributoAndamentoDTO = new AtributoAndamentoDTO();
             $objAtributoAndamentoDTO->setStrNome('ENTIDADE_ORIGEM_HIRARQUIA');
             $objAtributoAndamentoDTO->setStrValor($nome);
             $objAtributoAndamentoDTO->setStrIdOrigem($objNivel->numeroDeIdentificacaoDaEstrutura);
             $arrObjAtributoAndamentoDTO[] = $objAtributoAndamentoDTO;
-        }
+        
 
         $objAtividadeDTO = new AtividadeDTO();
         $objAtividadeDTO->setDblIdProtocolo($objProcedimentoDTO->getDblIdProcedimento());

--- a/tests/funcional/phpunit.xml
+++ b/tests/funcional/phpunit.xml
@@ -85,7 +85,7 @@
     <const name="CONTEXTO_ORGAO_B_DB_SEI_PASSWORD" value="sei_user" />
 
 
-    <!-- CONFIGURAÇÕES DE TESTE ÓRGÃO 3, caso de sem hierarquia pai -->
+    <!-- CONFIGURAÃ‡Ã•ES DE TESTE Ã“rgÃ£o 3, caso de sem hierarquia pai -->
     <const name="CONTEXTO_ORGAO_C" value="CONTEXTO_ORGAO_C" />
     <const name="CONTEXTO_ORGAO_C_URL" value="http://xxxxx/sei"/>
     <const name="CONTEXTO_ORGAO_C_SIGLA_ORGAO" value="ABC" />
@@ -101,15 +101,15 @@
     <const name="CONTEXTO_ORGAO_C_NOME_UNIDADE_SECUNDARIA" value="" />  
     <const name="CONTEXTO_ORGAO_C_SIGLA_UNIDADE_SECUNDARIA" value="" />
     <const name="CONTEXTO_ORGAO_C_SIGLA_UNIDADE_SECUNDARIA_HIERARQUIA" value="" />
-    <const name="CONTEXTO_ORGAO_C_TIPO_PROCESSO" value="Arrecadação: Cobrança" />    
-    <const name="CONTEXTO_ORGAO_C_TIPO_DOCUMENTO" value="Ofício" />
+    <const name="CONTEXTO_ORGAO_C_TIPO_PROCESSO" value="ArrecadaÃ§Ã£o: CobranÃ§a" />    
+    <const name="CONTEXTO_ORGAO_C_TIPO_DOCUMENTO" value="OfÃ­cio" />
     <const name="CONTEXTO_ORGAO_C_TIPO_DOCUMENTO_NAO_MAPEADO" value="Nota" />           
-    <const name="CONTEXTO_ORGAO_C_HIPOTESE_RESTRICAO" value="Documento Preparatório (Art. 7º, § 3º, da Lei nº 12.527/2011)" />    
-    <const name="CONTEXTO_ORGAO_C_HIPOTESE_RESTRICAO_NAO_MAPEADO" value="Informação Pessoal (Art. 31 da Lei nº 12.527/2011)" />
+    <const name="CONTEXTO_ORGAO_C_HIPOTESE_RESTRICAO" value="Documento PreparatÃ³rio (Art. 7Âº, Â§ 3Âº, da Lei nÂº 12.527/2011)" />    
+    <const name="CONTEXTO_ORGAO_C_HIPOTESE_RESTRICAO_NAO_MAPEADO" value="InformaÃ§Ã£o Pessoal (Art. 31 da Lei nÂº 12.527/2011)" />
     <const name="CONTEXTO_ORGAO_C_CARGO_ASSINATURA" value="Assessor(a)" />       
-    <const name="CONTEXTO_ORGAO_C_HIPOTESE_RESTRICAO_PADRAO" value="Controle Interno (Art. 26, § 3º, da Lei nº 10.180/2001)" />
-    <const name="CONTEXTO_ORGAO_C_LOCALIZACAO_CERTIFICADO_DIGITAL" value="/../assets/config/certificado_org2.pem" />
-    <const name="CONTEXTO_ORGAO_C_SENHA_CERTIFICADO_DIGITAL" value="n2TjrsC3TSFy9cRg" />
+    <const name="CONTEXTO_ORGAO_C_HIPOTESE_RESTRICAO_PADRAO" value="Controle Interno (Art. 26, Â§ 3Âº, da Lei nÂº 10.180/2001)" />
+    <const name="CONTEXTO_ORGAO_C_LOCALIZACAO_CERTIFICADO_DIGITAL" value="/../assets/config/certificado_org3.pem" />
+    <const name="CONTEXTO_ORGAO_C_SENHA_CERTIFICADO_DIGITAL" value="" />
     <const name="CONTEXTO_ORGAO_C_DB_SEI_DSN" value="mysql:host=127.0.0.1;port=33062;dbname=sei;" />
     <!-- <const name="CONTEXTO_ORGAO_C_DB_SEI_DSN" value="sqlsrv:server=localhost,14332; Database=sei" /> -->
     <!-- <const name="CONTEXTO_ORGAO_C_DB_SEI_DSN" value="oci:dbname=(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=localhost)(PORT=15212))(CONNECT_DATA=(SERVICE_NAME=XE)))" /> -->

--- a/tests/funcional/phpunit.xml
+++ b/tests/funcional/phpunit.xml
@@ -83,6 +83,38 @@
     <!-- <const name="CONTEXTO_ORGAO_B_DB_SEI_DSN" value="oci:dbname=(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=localhost)(PORT=15212))(CONNECT_DATA=(SERVICE_NAME=XE)))" /> -->
     <const name="CONTEXTO_ORGAO_B_DB_SEI_USER" value="sei_user" />
     <const name="CONTEXTO_ORGAO_B_DB_SEI_PASSWORD" value="sei_user" />
+
+
+    <!-- CONFIGURAÇÕES DE TESTE ÓRGÃO 3, caso de sem hierarquia pai -->
+    <const name="CONTEXTO_ORGAO_C" value="CONTEXTO_ORGAO_C" />
+    <const name="CONTEXTO_ORGAO_C_URL" value="http://xxxxx/sei"/>
+    <const name="CONTEXTO_ORGAO_C_SIGLA_ORGAO" value="ABC" />
+    <const name="CONTEXTO_ORGAO_C_NUMERO_SEI" value="159" />    
+    <const name="CONTEXTO_ORGAO_C_ID_REP_ESTRUTURAS" value="5" />
+    <const name="CONTEXTO_ORGAO_C_REP_ESTRUTURAS" value="RE CGPRO" />
+    <const name="CONTEXTO_ORGAO_C_SIGLA_UNIDADE" value="TESTE" />
+    <const name="CONTEXTO_ORGAO_C_ID_ESTRUTURA" value="121390" />
+    <const name="CONTEXTO_ORGAO_C_SIGLA_UNIDADE_HIERARQUIA" value="" />
+    <const name="CONTEXTO_ORGAO_C_NOME_UNIDADE" value="SEGES TESTE SEM PAI" />
+    <const name="CONTEXTO_ORGAO_C_USUARIO_LOGIN" value="teste" />
+    <const name="CONTEXTO_ORGAO_C_USUARIO_SENHA" value="teste" />        
+    <const name="CONTEXTO_ORGAO_C_NOME_UNIDADE_SECUNDARIA" value="" />  
+    <const name="CONTEXTO_ORGAO_C_SIGLA_UNIDADE_SECUNDARIA" value="" />
+    <const name="CONTEXTO_ORGAO_C_SIGLA_UNIDADE_SECUNDARIA_HIERARQUIA" value="" />
+    <const name="CONTEXTO_ORGAO_C_TIPO_PROCESSO" value="Arrecadação: Cobrança" />    
+    <const name="CONTEXTO_ORGAO_C_TIPO_DOCUMENTO" value="Ofício" />
+    <const name="CONTEXTO_ORGAO_C_TIPO_DOCUMENTO_NAO_MAPEADO" value="Nota" />           
+    <const name="CONTEXTO_ORGAO_C_HIPOTESE_RESTRICAO" value="Documento Preparatório (Art. 7º, § 3º, da Lei nº 12.527/2011)" />    
+    <const name="CONTEXTO_ORGAO_C_HIPOTESE_RESTRICAO_NAO_MAPEADO" value="Informação Pessoal (Art. 31 da Lei nº 12.527/2011)" />
+    <const name="CONTEXTO_ORGAO_C_CARGO_ASSINATURA" value="Assessor(a)" />       
+    <const name="CONTEXTO_ORGAO_C_HIPOTESE_RESTRICAO_PADRAO" value="Controle Interno (Art. 26, § 3º, da Lei nº 10.180/2001)" />
+    <const name="CONTEXTO_ORGAO_C_LOCALIZACAO_CERTIFICADO_DIGITAL" value="/../assets/config/certificado_org2.pem" />
+    <const name="CONTEXTO_ORGAO_C_SENHA_CERTIFICADO_DIGITAL" value="n2TjrsC3TSFy9cRg" />
+    <const name="CONTEXTO_ORGAO_C_DB_SEI_DSN" value="mysql:host=127.0.0.1;port=33062;dbname=sei;" />
+    <!-- <const name="CONTEXTO_ORGAO_C_DB_SEI_DSN" value="sqlsrv:server=localhost,14332; Database=sei" /> -->
+    <!-- <const name="CONTEXTO_ORGAO_C_DB_SEI_DSN" value="oci:dbname=(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=localhost)(PORT=15212))(CONNECT_DATA=(SERVICE_NAME=XE)))" /> -->
+    <const name="CONTEXTO_ORGAO_C_DB_SEI_USER" value="sei_user" />
+    <const name="CONTEXTO_ORGAO_C_DB_SEI_PASSWORD" value="sei_user" />
   </php>
 
   <testsuites>

--- a/tests/funcional/tests/TramiteProcessoUnidadeSemHierarquiaPai.php
+++ b/tests/funcional/tests/TramiteProcessoUnidadeSemHierarquiaPai.php
@@ -1,0 +1,33 @@
+<?php
+
+class TramiteProcessoUnidadeSemHierarquiaPaiTest extends CenarioBaseTestCase
+{
+    public static $remetente;
+    public static $destinatario;
+    public static $processoTeste;
+    public static $documentoTeste1;
+    public static $protocoloTeste;
+
+    /**
+     * Teste de trâmite externo de processo sem devolução para testar caso de hierarquia sem pai
+     *
+     * @group envio
+     *
+     * @return void
+     */
+    public function test_tramitar_processo_da_origem()
+    {
+        // Configuração do dados para teste do cenário
+        self::$remetente = $this->definirContextoTeste(CONTEXTO_ORGAO_A);
+        self::$destinatario = $this->definirContextoTeste(CONTEXTO_ORGAO_C);
+        self::$processoTeste = $this->gerarDadosProcessoTeste(self::$remetente);
+        self::$documentoTeste1 = $this->gerarDadosDocumentoInternoTeste(self::$remetente);
+
+        $documentos = array(self::$documentoTeste1);
+        $this->realizarTramiteExternoSemvalidacaoNoRemetente(self::$processoTeste, $documentos, self::$remetente, self::$destinatario);
+        self::$protocoloTeste = self::$processoTeste["PROTOCOLO"];
+
+        $paginaProcesso = new PaginaProcesso($this);
+        $this->assertStringNotContainsString(utf8_encode("externa para SEGES TESTE SEM PAI - - RE CGPRO"), $paginaProcesso->informacao());
+    }
+}

--- a/tests/unitario/rn/ProcessoEletronicoRNTest.php
+++ b/tests/unitario/rn/ProcessoEletronicoRNTest.php
@@ -74,5 +74,13 @@ final class ProcessoEletronicoRNTest extends TestCase
         $strResultadoAtual = $this->objProcessoEletronicoRN->reduzirCampoTexto($strTexto, $numTamanhoMaximo);
         $this->assertEquals($strResultadoEsperado, $strResultadoAtual);
         $this->assertTrue(strlen($strResultadoAtual) <= $numTamanhoMaximo);
+
+        // Teste considerando um texto longo com ultima palavra menor que a reticencias
+        $strTexto =             "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut lbore et dolore magna aliqua. Ut enim ad minim veniamr quis";
+        $strResultadoEsperado = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut lbore et dolore magna aliqua. Ut enim ad minim veniam ...";
+        $strResultadoAtual = $this->objProcessoEletronicoRN->reduzirCampoTexto($strTexto, 150);
+        $this->assertEquals($strResultadoEsperado, $strResultadoAtual);
+        $this->assertTrue(strlen($strResultadoAtual) <= 150);
+
     }
 }


### PR DESCRIPTION
O módulo estáva retornado no histórico '@UNIDADE_DESTINO_HIRARQUIA@' nos casos que não encontrava uma hierarquia superior. Agora retornará vazio.