### PR TITLE
Ajusta lógica para truncar texto longo

### DIFF
--- a/src/rn/ProcessoEletronicoRN.php
+++ b/src/rn/ProcessoEletronicoRN.php
@@ -1972,6 +1972,7 @@ class ProcessoEletronicoRN extends InfraRN
             $strUltimaPalavra = $arrStrTokens[count($arrStrTokens) - 1];
 
             $numTamanhoUltimaPalavra = strlen($strUltimaPalavra) > $numTamanhoMaximoPalavra ? strlen($strReticencias) : strlen($strUltimaPalavra);
+            $numTamanhoUltimaPalavra = $numTamanhoUltimaPalavra < strlen($strReticencias) ? strlen($strReticencias) : $numTamanhoUltimaPalavra;
             $strTexto = substr($strTexto, 0, strlen($strTexto) - $numTamanhoUltimaPalavra);
             $strTexto = trim($strTexto) . $strReticencias;
         }

--- a/tests/unitario/rn/ProcessoEletronicoRNTest.php
+++ b/tests/unitario/rn/ProcessoEletronicoRNTest.php
@@ -74,5 +74,13 @@ final class ProcessoEletronicoRNTest extends TestCase
         $strResultadoAtual = $this->objProcessoEletronicoRN->reduzirCampoTexto($strTexto, $numTamanhoMaximo);
         $this->assertEquals($strResultadoEsperado, $strResultadoAtual);
         $this->assertTrue(strlen($strResultadoAtual) <= $numTamanhoMaximo);
+
+        // Teste considerando um texto longo com ultima palavra menor que a reticencias
+        $strTexto =             "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut lbore et dolore magna aliqua. Ut enim ad minim veniamr quis";
+        $strResultadoEsperado = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut lbore et dolore magna aliqua. Ut enim ad minim veniam ...";
+        $strResultadoAtual = $this->objProcessoEletronicoRN->reduzirCampoTexto($strTexto, 150);
+        $this->assertEquals($strResultadoEsperado, $strResultadoAtual);
+        $this->assertTrue(strlen($strResultadoAtual) <= 150);
+
     }
 }


### PR DESCRIPTION
A lógica atual apresentava erros se a última palavra era menor que a reticencia.

Closes #63