### PR TITLE
Ajuste para tramitar processo aberto no SEI3

### DIFF
--- a/docs/changelogs/CHANGELOG-3.1.2.md
+++ b/docs/changelogs/CHANGELOG-3.1.2.md
@@ -1,0 +1,23 @@
+# NOTAS DE VERSÃO MOD-SEI-PEN (versão 3.1.2)
+
+Este documento descreve as principais mudanças aplicadas nesta versão do módulo de integração do SEI com o Barramento de Serviços do PEN. 
+
+As melhorias entregues em cada uma das versões são cumulativas, ou seja, contêm todas as implementações realizada em versões anteriores.
+
+Esta versão já é compatível com as seguintes versões do SEI:
+-3.1.x
+-4.0.0
+
+Para maiores informações sobre os procedimentos de instalação ou atualização, acesse os seguintes documentos localizados no pacote de distribuição mod-sei-pen-VERSAO.zip:
+
+* **INSTALACAO.md** - Procedimento de instalação e configuração do módulo
+* **ATUALIZACAO.md** - Procedimento específicos para atualização de uma versão anterior
+
+
+## Lista de Melhorias e Correções de Problemas
+
+
+#### Issue #112 - Erro ao tramitar processo aberto no SEI3 após atualizar pro SEI4
+
+Ocorre erro de hash no próprio órgão que envia o processo.
+

--- a/src/PENIntegracao.php
+++ b/src/PENIntegracao.php
@@ -2,7 +2,7 @@
 
 class PENIntegracao extends SeiIntegracao
 {
-    const VERSAO_MODULO = "3.1.1";
+    const VERSAO_MODULO = "3.1.2";
     const PARAMETRO_VERSAO_MODULO_ANTIGO = 'PEN_VERSAO_MODULO_SEI';
     const PARAMETRO_VERSAO_MODULO = 'VERSAO_MODULO_PEN';
 

--- a/src/rn/ExpedirProcedimentoRN.php
+++ b/src/rn/ExpedirProcedimentoRN.php
@@ -1326,6 +1326,12 @@ class ExpedirProcedimentoRN extends InfraRN {
                 }
             }
 
+            //Caso o hash ainda esteja inconsistente iremos usar a logica do  SEI 3.1.0
+            $hashDoComponenteDigital = base64_encode(hash(self::ALGORITMO_HASH_DOCUMENTO, $strConteudoAssinatura, true));
+            if(isset($hashDoComponenteDigitalAnterior) && $hashDoComponenteDigital <> $hashDoComponenteDigitalAnterior){
+                $strConteudoAssinatura = $this->obterConteudoInternoAssinatura($objDocumentoDTO->getDblIdDocumento(),false,true);
+            }
+
             //Caso o hash ainda esteja inconsistente teremos que forcar a geracao do arquivo usando as funções do sei 3.0.11
             $hashDoComponenteDigital = base64_encode(hash(self::ALGORITMO_HASH_DOCUMENTO, $strConteudoAssinatura, true));
             if(isset($hashDoComponenteDigitalAnterior) && $hashDoComponenteDigital <> $hashDoComponenteDigitalAnterior){

--- a/src/scripts/sei_atualizar_versao_modulo_pen.php
+++ b/src/scripts/sei_atualizar_versao_modulo_pen.php
@@ -105,6 +105,7 @@ class PenAtualizarSeiRN extends PenAtualizadorRN {
                 case '3.0.0': $this->instalarV3001();
                 case '3.0.1': $this->instalarV3010();
                 case '3.1.0': $this->instalarV3011();
+                case '3.1.1': $this->instalarV3012();
                     break;
                 default:
                 $this->finalizar('VERSAO DO MÓDULO JÁ CONSTA COMO ATUALIZADA');
@@ -2178,6 +2179,11 @@ class PenAtualizarSeiRN extends PenAtualizadorRN {
     protected function instalarV3011()
     {
         $this->atualizarNumeroVersao("3.1.1");
+    }
+
+    protected function instalarV3012()
+    {
+        $this->atualizarNumeroVersao("3.1.2");
     }
 }
 

--- a/src/scripts/sip_atualizar_versao_modulo_pen.php
+++ b/src/scripts/sip_atualizar_versao_modulo_pen.php
@@ -135,6 +135,7 @@ class PenAtualizarSipRN extends InfraRN {
                 case '3.0.0': $this->instalarV3001();
                 case '3.0.1': $this->instalarV3010();
                 case '3.1.0': $this->instalarV3011();
+                case '3.1.1': $this->instalarV3012();
                     break;
 
                 default:
@@ -1425,6 +1426,11 @@ class PenAtualizarSipRN extends InfraRN {
     protected function instalarV3011()
     {
 	    $this->atualizarNumeroVersao("3.1.1");
+    }
+
+    protected function instalarV3012()
+    {
+	    $this->atualizarNumeroVersao("3.1.2");
     }
 }
 


### PR DESCRIPTION
Com a atualização para o SEI4, os processos abertos anteriormente no SEI3 estavam resultando em erro de hash.

Closes #112