### PR TITLE
Correções de erros no tramite de documento movidos e na funcionalidade de tramitação em lote

### DIFF
--- a/src/PENIntegracao.php
+++ b/src/PENIntegracao.php
@@ -61,8 +61,13 @@ class PENIntegracao extends SeiIntegracao
             $arrObjProcedimentoDTO = $objAtividadeRN->listarPendenciasRN0754($objPesquisaPendenciaDTO);
             $numRegistros = count($arrObjProcedimentoDTO);
 
+            $objPenUnidadeDTO = new PenUnidadeDTO();
+            $objPenUnidadeDTO->retNumIdUnidade();
+            $objPenUnidadeDTO->setNumIdUnidade(SessaoSEI::getInstance()->getNumIdUnidadeAtual());
+            $objPenUnidadeRN = new PenUnidadeRN();
+
             //Apresenta o botão de expedir processo
-            if ($numRegistros > 0) {
+            if ($numRegistros > 0 && $objPenUnidadeRN->contar($objPenUnidadeDTO) != 0) {
                 $numTabBotao = $objPaginaSEI->getProxTabBarraComandosSuperior();
                 $strAcoesProcedimento .= '<a href="#" onclick="return acaoControleProcessos(\'' . $objSessaoSEI->assinarLink('controlador.php?acao=pen_expedir_lote&acao_origem=' . $_GET['acao'] . '&acao_retorno=' . $_GET['acao']) . '\', true, false);" tabindex="' . $numTabBotao . '" class="botaoSEI">';
                 $strAcoesProcedimento .= '<img class="infraCorBarraSistema" src="' . ProcessoEletronicoINT::getCaminhoIcone("/pen_expedir_procedimento.gif",$this->getDiretorioImagens()) . '" class="infraCorBarraSistema" alt="Envio Externo de Processo em Lote" title="Envio Externo de Processo em Lote" />';

--- a/src/rn/PenLoteProcedimentoRN.php
+++ b/src/rn/PenLoteProcedimentoRN.php
@@ -98,12 +98,9 @@ class PenLoteProcedimentoRN extends InfraRN {
 
     }
 
-    protected function desbloquearProcessoLoteControlado($dblIdProcedimento)
+    public static function desbloquearProcessoLoteControlado($dblIdProcedimento)
     {
         try{
-
-            //Desbloqueia o processo
-            ProcessoEletronicoRN::desbloquearProcesso($dblIdProcedimento);
 
             $objPenLoteProcedimentoDTO = new PenLoteProcedimentoDTO();
             $objPenLoteProcedimentoDTO->retNumIdLote();
@@ -122,6 +119,13 @@ class PenLoteProcedimentoRN extends InfraRN {
 
             $objPenLoteProcedimentoRN = new PenLoteProcedimentoRN();
             $objPenLoteProcedimentoRN->alterarLoteProcedimento($objPenExpedirLoteDTO);
+
+            //Desbloqueia o processo
+            $objProtocoloRN = new ProtocoloRN();
+            $objProtocoloDTO = new ProtocoloDTO();
+            $objProtocoloDTO->setStrStaEstado(ProtocoloRN::$TE_NORMAL);
+            $objProtocoloDTO->setDblIdProtocolo($dblIdProcedimento);
+            $objProtocoloRN->alterarRN0203($objProtocoloDTO);
 
             //Cria o Objeto que registrar a Atividade de cancelamento
             $objAtividadeDTO = new AtividadeDTO();

--- a/src/rn/ProcessoEletronicoRN.php
+++ b/src/rn/ProcessoEletronicoRN.php
@@ -1009,6 +1009,7 @@ class ProcessoEletronicoRN extends InfraRN
                 $objComponenteDigitalDTOFiltro->setDblIdProcedimento($objComponenteDigitalDTO->getDblIdProcedimento());
                 $objComponenteDigitalDTOFiltro->setDblIdDocumento($objComponenteDigitalDTO->getDblIdDocumento());
                 $objComponenteDigitalDTOFiltro->setNumOrdem($objComponenteDigitalDTO->getNumOrdem());
+                $objComponenteDigitalDTOFiltro->setNumOrdemDocumento($objComponenteDigitalDTO->getNumOrdemDocumento());
 
                 if($objComponenteDigitalBD->contar($objComponenteDigitalDTOFiltro) == 0){
                     $objComponenteDigitalDTO = $objComponenteDigitalBD->cadastrar($objComponenteDigitalDTO);

--- a/src/rn/ProcessoEletronicoRN.php
+++ b/src/rn/ProcessoEletronicoRN.php
@@ -2100,9 +2100,9 @@ class ProcessoEletronicoRN extends InfraRN
      * sua atual associação com o processo
      *
      * @param Num $idProcedimento
+     * @param Num parDblIdDocumento Filtro de dados de associação de um documento específico
      * @return array Lista de Ids dos documentos do processo em ordem
      */
-    //public function listarSequenciaDocumentos($idProcedimento)
     public function listarAssociacoesDocumentos($idProcedimento)
     {
         if(!isset($idProcedimento)){

--- a/tests/funcional/src/paginas/PaginaIncluirDocumento.php
+++ b/tests/funcional/src/paginas/PaginaIncluirDocumento.php
@@ -152,7 +152,7 @@ class PaginaIncluirDocumento extends PaginaTeste
         return trim($this->test->byId('anchor' . $query["id_documento"])->text());
     }
 
-    public function gerarDocumentoExternoTeste(array $dadosDocumento)
+    public function gerarDocumentoExternoTeste(array $dadosDocumento, $comAnexo)
     {
         $this->test->frame(null);
         $this->test->frame("ifrVisualizacao");
@@ -176,7 +176,9 @@ class PaginaIncluirDocumento extends PaginaTeste
 
         $this->dataElaboracao($dadosDocumento["DATA_ELABORACAO"]);
         $this->formato($dadosDocumento["FORMATO_DOCUMENTO"]);
-        $this->anexo($dadosDocumento["ARQUIVO"]);
+        if($comAnexo){
+            $this->anexo($dadosDocumento["ARQUIVO"]);
+        }
         $this->observacoes($dadosDocumento["OBSERVACOES"]);
         $this->selecionarRestricao($dadosDocumento["RESTRICAO"], $dadosDocumento["HIPOTESE_LEGAL"]);
         $this->salvarDocumento();

--- a/tests/funcional/src_sei4/paginas/PaginaIncluirDocumento.php
+++ b/tests/funcional/src_sei4/paginas/PaginaIncluirDocumento.php
@@ -152,7 +152,7 @@ class PaginaIncluirDocumento extends PaginaTeste
         return trim($this->test->byId('anchor' . $query["id_documento"])->text());
     }
 
-    public function gerarDocumentoExternoTeste(array $dadosDocumento)
+    public function gerarDocumentoExternoTeste(array $dadosDocumento, $comAnexo)
     {
         $this->test->frame(null);
         $this->test->frame("ifrVisualizacao");
@@ -176,7 +176,9 @@ class PaginaIncluirDocumento extends PaginaTeste
 
         $this->dataElaboracao($dadosDocumento["DATA_ELABORACAO"]);
         $this->formato($dadosDocumento["FORMATO_DOCUMENTO"]);
-        $this->anexo($dadosDocumento["ARQUIVO"]);
+        if($comAnexo){
+            $this->anexo($dadosDocumento["ARQUIVO"]);
+        }
         $this->observacoes($dadosDocumento["OBSERVACOES"]);
         $this->selecionarRestricao($dadosDocumento["RESTRICAO"], $dadosDocumento["HIPOTESE_LEGAL"]);
         $this->salvarDocumento();

--- a/tests/funcional/tests/CenarioBaseTestCase.php
+++ b/tests/funcional/tests/CenarioBaseTestCase.php
@@ -233,10 +233,10 @@ class CenarioBaseTestCase extends Selenium2TestCase
         sleep(2);
     }
 
-    protected function cadastrarDocumentoExterno($dadosDocumentoExterno)
+    protected function cadastrarDocumentoExterno($dadosDocumentoExterno, $comAnexo=true)
     {
         $this->paginaProcesso->selecionarProcesso();
-        $this->paginaIncluirDocumento->gerarDocumentoExternoTeste($dadosDocumentoExterno);
+        $this->paginaIncluirDocumento->gerarDocumentoExternoTeste($dadosDocumentoExterno, $comAnexo);
         sleep(2);
     }
 
@@ -349,7 +349,16 @@ class CenarioBaseTestCase extends Selenium2TestCase
         }
 
         if($verificarProcessoRejeitado){
-            $this->assertTrue($this->paginaConsultarAndamentos->contemTramiteProcessoRejeitado($unidadeDestino, utf8_encode($motivoRecusa)));
+
+            $motivoRecusa = utf8_encode($motivoRecusa);
+            $this->waitUntil(function($testCase) use ($unidadeDestino, $motivoRecusa) {
+                sleep(5);
+                $testCase->refresh();
+                $testCase->paginaProcesso->navegarParaConsultarAndamentos();
+                $this->assertTrue($testCase->paginaConsultarAndamentos->contemTramiteProcessoRejeitado($unidadeDestino, $motivoRecusa));
+                return true;
+            }, PEN_WAIT_TIMEOUT);
+
         }
     }
 

--- a/tests/funcional/tests/RecebimentoRecusaJustificativaGrandeTest.php
+++ b/tests/funcional/tests/RecebimentoRecusaJustificativaGrandeTest.php
@@ -1,0 +1,118 @@
+<?php
+
+use \utilphp\util;
+
+class RecebimentoRecusaJustificativaGrandeTest extends CenarioBaseTestCase
+{
+
+    protected $destinatarioWs;
+    protected $servicoPEN;
+    public static $remetente;
+    public static $destinatario;    
+    public static $processoTeste;
+    public static $documentoTeste;
+    public static $protocoloTeste;
+
+
+    public function setUp(): void
+    {
+        parent::setup();
+
+        // Carregar contexto de testes e dados sobre certificado digital
+        $this->destinatarioWs = $this->definirContextoTeste(CONTEXTO_ORGAO_B);
+
+        // Instanciar objeto de teste utilizando o BeSimpleSoap
+        $localCertificado = $this->destinatarioWs['LOCALIZACAO_CERTIFICADO_DIGITAL'];
+        $senhaCertificado = $this->destinatarioWs['SENHA_CERTIFICADO_DIGITAL'];
+        $this->servicoPEN = $this->instanciarApiDeIntegracao($localCertificado, $senhaCertificado);
+    }
+
+    /**
+     * Teste de trâmite externo de processo com devolução para a mesma unidade de origem
+     *
+     * @group envio
+     *
+     * @return void
+     */
+    public function test_tramitar_processo_da_origem()
+    {
+
+        // Configuração do dados para teste do cenário
+        self::$remetente = $this->definirContextoTeste(CONTEXTO_ORGAO_A);
+        self::$destinatario = $this->definirContextoTeste(CONTEXTO_ORGAO_B);
+        self::$processoTeste = $this->gerarDadosProcessoTeste(self::$remetente);
+        self::$documentoTeste = $this->gerarDadosDocumentoInternoTeste(self::$remetente);
+
+        $this->realizarTramiteExternoSemvalidacaoNoRemetente(self::$processoTeste, self::$documentoTeste, self::$remetente, self::$destinatario);
+        self::$protocoloTeste = self::$processoTeste["PROTOCOLO"];
+
+        $bancoOrgaoA = new DatabaseUtils(CONTEXTO_ORGAO_A);
+        $id_tramite = $bancoOrgaoA->query("select max(id_tramite) as id_tramite from sei.md_pen_componente_digital where protocolo = ?", array(self::$protocoloTeste));
+        //recusa o tramite contendo justificativa grande
+        $this->recusarTramite($this->servicoPEN, $id_tramite[0]["id_tramite"]);        
+    }
+
+    /**
+     * Teste de verificação do correto recebimento do processo no destinatário
+     *
+     * @group verificacao_recebimento
+     *
+     * @depends test_tramitar_processo_da_origem
+     *
+     * @return void
+     */
+    public function test_verificar_destino_processo_para_devolucao()
+    {
+        // Configuração do dados para teste do cenário
+        self::$remetente = $this->definirContextoTeste(CONTEXTO_ORGAO_A);
+
+        $this->acessarSistema(self::$remetente['URL'], self::$remetente['SIGLA_UNIDADE'], self::$remetente['LOGIN'], self::$remetente['SENHA']);
+        $this->abrirProcesso(self::$protocoloTeste);
+        $this->assertTrue($this->paginaProcesso->processoAberto());
+
+        $unidade = mb_convert_encoding(self::$destinatario['NOME_UNIDADE'], "ISO-8859-1");
+        $this->validarRecibosTramite(sprintf("Trâmite externo do Processo %s para %s", self::$protocoloTeste, $unidade) , true, false);
+        $this->validarHistoricoTramite(self::$destinatario['NOME_UNIDADE'], true, false, true, sprintf("An exception occurred while executing 'INSERT INTO juntadas (numeracao_sequencial, movimento, ativo, vinculada, criado_em, atualizado_em, id, uuid, documentos_juntado_id, volumes_id, atividades_id, tarefas_id, comunicacoes_id, origem_dados_id, criado_por, atualizado_por) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)' with params [1, 'DOCUMENTO RECEBIDO VIA INTEGRA\u00c7\u00c3O COM O BARRAMENTO', 1, 0, '2021-12-02 14:21:48', '2021-12-02 14:21:48', 1317074776, '06ba31e8-75ad-4111-82d ..."));
+
+        //Verifica se os í­cones de alerta de recusa foram adicionados e se o processo continua aberto na unidade
+        $this->paginaBase->navegarParaControleProcesso();
+        $this->assertTrue($this->paginaControleProcesso->contemProcesso(self::$protocoloTeste));
+        $this->assertTrue($this->paginaControleProcesso->contemAlertaProcessoRecusado(self::$protocoloTeste));
+    }
+
+    private function recusarTramite($servicoPEN, $id_tramite)
+    {
+        $justificativa = "An exception occurred while executing 'INSERT INTO juntadas (numeracao_sequencial, movimento, ativo, vinculada, criado_em, atualizado_em, id, uuid, documentos_juntado_id, volumes_id, atividades_id, tarefas_id, comunicacoes_id, origem_dados_id, criado_por, atualizado_por) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)' with params [1, 'DOCUMENTO RECEBIDO VIA INTEGRA\u00c7\u00c3O COM O BARRAMENTO', 1, 0, '2021-12-02 14:21:48', '2021-12-02 14:21:48', 1317074776, '06ba31e8-75ad-4111-82dc-6f451f51825e', 1333864526, null, null, null, null, 3534979787, null, null]: ORA-00001: restrição exclusiva (SAPIENS.UNIQ_867686DHDKJ97876) violada";
+
+        $parametros = new stdClass();
+        $parametros->recusaDeTramite = new stdClass();
+        $parametros->recusaDeTramite->IDT = $id_tramite;
+        $parametros->recusaDeTramite->justificativa = utf8_encode($justificativa);
+        $parametros->recusaDeTramite->motivo = "99";
+        return $servicoPEN->recusarTramite($parametros);
+    }
+
+
+    private function instanciarApiDeIntegracao($localCertificado, $senhaCertificado)
+    {
+        $connectionTimeout = 600;
+        $options = array(
+            'soap_version' => SOAP_1_1
+            , 'local_cert' => $localCertificado
+            , 'passphrase' => $senhaCertificado
+            , 'resolve_wsdl_remote_includes' => true
+            , 'cache_wsdl'=> BeSimple\SoapCommon\Cache::TYPE_NONE
+            , 'connection_timeout' => $connectionTimeout
+            , CURLOPT_TIMEOUT => $connectionTimeout
+            , CURLOPT_CONNECTTIMEOUT => $connectionTimeout
+            , 'encoding' => 'UTF-8'
+            , 'attachment_type' => BeSimple\SoapCommon\Helper::ATTACHMENTS_TYPE_MTOM
+            , 'ssl' => array(
+                'allow_self_signed' => true,
+            ),
+        );
+
+        return new BeSimple\SoapClient\SoapClient(PEN_ENDERECO_WEBSERVICE, $options);
+
+    }
+}

--- a/tests/funcional/tests/TramiteProcessoContendoDocumentoMovidoSemAnexoTest.php
+++ b/tests/funcional/tests/TramiteProcessoContendoDocumentoMovidoSemAnexoTest.php
@@ -1,0 +1,246 @@
+<?php
+
+/**
+ * Testes de trâmite de processos contendo um documento movido sem anexo
+ *
+ * Este mesmo documento deve ser recebido e assinalado como cancelado no destinatário e
+ * a devolução do mesmo processo não deve ser impactado pela inserção de outros documentos
+ */
+class TramiteProcessoContendoDocumentoMovidoSemAnexoTest extends CenarioBaseTestCase
+{
+    public static $remetente;
+    public static $destinatario;
+    public static $processoTeste;
+    public static $documentoTeste1;
+    public static $documentoTeste2;
+    public static $documentoTeste3;
+    public static $documentoTeste4;
+    public static $protocoloTeste;
+
+    /**
+     * Teste inicial de trâmite de um processo contendo um documento movido
+     *
+     * @group envio
+     *
+     * @return void
+     */
+    public function test_tramitar_processo_contendo_documento_movido_sem_anexo()
+    {
+        self::$remetente = $this->definirContextoTeste(CONTEXTO_ORGAO_A);
+        self::$destinatario = $this->definirContextoTeste(CONTEXTO_ORGAO_B);
+
+        // Definição de dados de teste do processo principal
+        self::$processoTeste = $this->gerarDadosProcessoTeste(self::$remetente);
+        $processoSecundarioTeste = $this->gerarDadosProcessoTeste(self::$remetente);
+        self::$documentoTeste1 = $this->gerarDadosDocumentoExternoTeste(self::$remetente);
+        self::$documentoTeste2 = $this->gerarDadosDocumentoInternoTeste(self::$remetente);
+
+        // Acessar sistema do this->REMETENTE do processo
+        $this->acessarSistema(self::$remetente['URL'], self::$remetente['SIGLA_UNIDADE'], self::$remetente['LOGIN'], self::$remetente['SENHA']);
+
+        // Criar processo secundário para o qual o documento será movido
+        $protocoloSecundarioTeste = $this->cadastrarProcesso($processoSecundarioTeste);
+
+        // Cadastrar novo processo de teste e incluir documentos a ser movido
+        $this->paginaBase->navegarParaControleProcesso();
+        self::$protocoloTeste = $this->cadastrarProcesso(self::$processoTeste);
+        $this->cadastrarDocumentoExterno(self::$documentoTeste1, false);
+        $this->paginaDocumento->navegarParaMoverDocumento();
+        $this->paginaMoverDocumento->moverDocumentoParaProcesso($protocoloSecundarioTeste, "Motivo de teste");
+
+        // Cadastramento de documento adicional
+        $this->cadastrarDocumentoInterno(self::$documentoTeste2);
+        $this->assinarDocumento(self::$remetente['ORGAO'], self::$remetente['CARGO_ASSINATURA'], self::$remetente['SENHA']);
+
+        // Trâmitar Externamento processo para órgão/unidade destinatária
+        $this->tramitarProcessoExternamente(
+            self::$protocoloTeste,
+            self::$destinatario['REP_ESTRUTURAS'],
+            self::$destinatario['NOME_UNIDADE'],
+            self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'],
+            false
+        );
+    }
+
+
+    /**
+     * Teste de verificação do correto envio do processo no sistema remetente
+     *
+     * @group verificacao_envio
+     *
+     * @depends test_tramitar_processo_contendo_documento_movido_sem_anexo
+     *
+     * @return void
+     */
+    public function test_verificar_origem_processo()
+    {
+        $orgaosDiferentes = self::$remetente['URL'] != self::$destinatario['URL'];
+        $this->acessarSistema(self::$remetente['URL'], self::$remetente['SIGLA_UNIDADE'], self::$remetente['LOGIN'], self::$remetente['SENHA']);
+        $this->abrirProcesso(self::$protocoloTeste);
+
+        $this->waitUntil(function ($testCase) use (&$orgaosDiferentes) {
+            sleep(5);
+            $testCase->refresh();
+            $paginaProcesso = new PaginaProcesso($testCase);
+            $testCase->assertStringNotContainsString(utf8_encode("Processo em trâmite externo para "), $paginaProcesso->informacao());
+            $testCase->assertFalse($paginaProcesso->processoAberto());
+            $testCase->assertEquals($orgaosDiferentes, $paginaProcesso->processoBloqueado());
+            return true;
+        }, PEN_WAIT_TIMEOUT);
+
+        $unidade = mb_convert_encoding(self::$destinatario['NOME_UNIDADE'], "ISO-8859-1");
+        $mensagemRecibo = sprintf("Trâmite externo do Processo %s para %s", self::$protocoloTeste, $unidade);
+        $this->validarRecibosTramite($mensagemRecibo, true, true);
+        $this->validarHistoricoTramite(self::$destinatario['NOME_UNIDADE'], true, true);
+        $this->validarProcessosTramitados(self::$protocoloTeste, $orgaosDiferentes);
+    }
+
+    /**
+     * Teste de verificação do correto recebimento do processo com documento movido no destinatário
+     *
+     * @group verificacao_recebimento
+     *
+     * @depends test_verificar_origem_processo
+     *
+     * @return void
+     */
+    public function test_verificar_destino_processo_com_documento_movido_sem_anexo()
+    {
+        $strProtocoloTeste = self::$protocoloTeste;
+        $orgaosDiferentes = self::$remetente['URL'] != self::$destinatario['URL'];
+
+        $this->acessarSistema(self::$destinatario['URL'], self::$destinatario['SIGLA_UNIDADE'], self::$destinatario['LOGIN'], self::$destinatario['SENHA']);
+        $this->abrirProcesso(self::$protocoloTeste);
+
+        $strTipoProcesso = utf8_encode("Tipo de processo no órgão de origem: ");
+        $strTipoProcesso .= self::$processoTeste['TIPO_PROCESSO'];
+        $strObservacoes = $orgaosDiferentes ? $strTipoProcesso : null;
+        $this->validarDadosProcesso(
+            self::$processoTeste['DESCRICAO'],
+            self::$processoTeste['RESTRICAO'],
+            $strObservacoes,
+            array(self::$processoTeste['INTERESSADOS'])
+        );
+
+        $this->validarRecibosTramite("Recebimento do Processo $strProtocoloTeste", false, true);
+
+        // Validação dos dados do processo principal
+        $listaDocumentosProcessoPrincipal = $this->paginaProcesso->listarDocumentos();
+        $this->assertEquals(2, count($listaDocumentosProcessoPrincipal));
+        $this->validarDocumentoCancelado($listaDocumentosProcessoPrincipal[0]);
+        $this->validarDadosDocumento($listaDocumentosProcessoPrincipal[1], self::$documentoTeste2, self::$destinatario);
+    }
+
+
+    /**
+     * Teste de trâmite externo de processo realizando a devolução para a mesma unidade de origem contendo
+     * mais dois documentos, sendo um deles movido
+     *
+     * @group envio
+     *
+     * @depends test_verificar_destino_processo_com_documento_movido_sem_anexo
+     *
+     * @return void
+     */
+    public function test_devolucao_processo_para_origem_com_novo_documento_movido_sem_anexo()
+    {
+        self::$remetente = $this->definirContextoTeste(CONTEXTO_ORGAO_B);
+        self::$destinatario = $this->definirContextoTeste(CONTEXTO_ORGAO_A);
+
+        // Criar processo secundário para o qual o novo documento será movido
+        $processoSecundarioTeste = $this->gerarDadosProcessoTeste(self::$remetente);
+        self::$documentoTeste3 = $this->gerarDadosDocumentoExternoTeste(self::$remetente);
+        self::$documentoTeste4 = $this->gerarDadosDocumentoInternoTeste(self::$remetente);
+
+        // Acessar sistema do this->REMETENTE do processo
+        $this->acessarSistema(self::$remetente['URL'], self::$remetente['SIGLA_UNIDADE'], self::$remetente['LOGIN'], self::$remetente['SENHA']);
+
+        $protocoloSecundarioTeste = $this->cadastrarProcesso($processoSecundarioTeste);
+
+        // Incluir novos documentos ao processo para ser movido
+        $this->abrirProcesso(self::$protocoloTeste);
+        $this->cadastrarDocumentoExterno(self::$documentoTeste3, false);
+        $this->paginaDocumento->navegarParaMoverDocumento();
+        $this->paginaMoverDocumento->moverDocumentoParaProcesso($protocoloSecundarioTeste, "Motivo de teste");
+
+        // Cadastramento de documento adicional
+        $this->cadastrarDocumentoInterno(self::$documentoTeste4);
+        $this->assinarDocumento(self::$remetente['ORGAO'], self::$remetente['CARGO_ASSINATURA'], self::$remetente['SENHA']);
+
+        // Trâmitar Externamento processo para órgão/unidade destinatária
+        $this->tramitarProcessoExternamente(
+            self::$protocoloTeste,
+            self::$destinatario['REP_ESTRUTURAS'],
+            self::$destinatario['NOME_UNIDADE'],
+            self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'],
+            false
+        );
+    }
+
+
+    /**
+     * Teste de verificação do correto envio do processo no sistema remetente
+     *
+     * @group verificacao_envio
+     *
+     * @depends test_devolucao_processo_para_origem_com_novo_documento_movido_sem_anexo
+     *
+     * @return void
+     */
+    public function test_verificar_devolucao_origem_processo()
+    {
+        $orgaosDiferentes = self::$remetente['URL'] != self::$destinatario['URL'];
+
+        $this->acessarSistema(self::$remetente['URL'], self::$remetente['SIGLA_UNIDADE'], self::$remetente['LOGIN'], self::$remetente['SENHA']);
+        $this->abrirProcesso(self::$protocoloTeste);
+
+        $this->waitUntil(function ($testCase) use (&$orgaosDiferentes) {
+            sleep(5);
+            $testCase->refresh();
+            $paginaProcesso = new PaginaProcesso($testCase);
+            $testCase->assertStringNotContainsString(utf8_encode("Processo em trâmite externo para "), $paginaProcesso->informacao());
+            $testCase->assertFalse($paginaProcesso->processoAberto());
+            $testCase->assertEquals($orgaosDiferentes, $paginaProcesso->processoBloqueado());
+            return true;
+        }, PEN_WAIT_TIMEOUT);
+
+        $unidade = mb_convert_encoding(self::$destinatario['NOME_UNIDADE'], "ISO-8859-1");
+        $mensagemRecibo = sprintf("Trâmite externo do Processo %s para %s", self::$protocoloTeste, $unidade);
+        $this->validarRecibosTramite($mensagemRecibo, true, true);
+        $this->validarHistoricoTramite(self::$destinatario['NOME_UNIDADE'], true, true);
+        $this->validarProcessosTramitados(self::$protocoloTeste, $orgaosDiferentes);
+    }
+
+    /**
+     * Teste de verificação da correta devolução do processo no destinatário
+     *
+     * @group verificacao_recebimento
+     *
+     * @depends test_verificar_devolucao_origem_processo
+     *
+     * @return void
+     */
+    public function test_verificar_devolucao_destino_processo_com_dois_documentos_movidos_sem_anexo()
+    {
+        $strProtocoloTeste = self::$protocoloTeste;
+        $this->acessarSistema(self::$destinatario['URL'], self::$destinatario['SIGLA_UNIDADE'], self::$destinatario['LOGIN'], self::$destinatario['SENHA']);
+        $this->abrirProcesso(self::$protocoloTeste);
+
+        $this->validarDadosProcesso(
+            self::$processoTeste['DESCRICAO'],
+            self::$processoTeste['RESTRICAO'],
+            self::$processoTeste['OBSERVACOES'],
+            array(self::$processoTeste['INTERESSADOS'])
+        );
+
+        $this->validarRecibosTramite("Recebimento do Processo $strProtocoloTeste", false, true);
+
+        // Validação dos dados do processo principal
+        $listaDocumentosProcesso = $this->paginaProcesso->listarDocumentos();
+        $this->assertEquals(4, count($listaDocumentosProcesso));
+        $this->validarDocumentoMovido($listaDocumentosProcesso[0]);
+        $this->validarDadosDocumento($listaDocumentosProcesso[1], self::$documentoTeste2, self::$destinatario);
+        $this->validarDocumentoCancelado($listaDocumentosProcesso[2]);
+        $this->validarDadosDocumento($listaDocumentosProcesso[3], self::$documentoTeste4, self::$destinatario);
+    }
+}

--- a/tests/funcional/tests_sei4/CenarioBaseTestCase.php
+++ b/tests/funcional/tests_sei4/CenarioBaseTestCase.php
@@ -246,10 +246,10 @@ class CenarioBaseTestCase extends Selenium2TestCase
         sleep(2);
     }
 
-    protected function cadastrarDocumentoExterno($dadosDocumentoExterno)
+    protected function cadastrarDocumentoExterno($dadosDocumentoExterno, $comAnexo=true)
     {
         $this->paginaProcesso->selecionarProcesso();
-        $this->paginaIncluirDocumento->gerarDocumentoExternoTeste($dadosDocumentoExterno);
+        $this->paginaIncluirDocumento->gerarDocumentoExternoTeste($dadosDocumentoExterno, $comAnexo);
         sleep(2);
     }
 
@@ -404,7 +404,16 @@ class CenarioBaseTestCase extends Selenium2TestCase
         }
 
         if($verificarProcessoRejeitado){
-            $this->assertTrue($this->paginaConsultarAndamentos->contemTramiteProcessoRejeitado($unidadeDestino, utf8_encode($motivoRecusa)));
+
+            $motivoRecusa = utf8_encode($motivoRecusa);
+            $this->waitUntil(function($testCase) use ($unidadeDestino, $motivoRecusa) {
+                sleep(5);
+                $testCase->refresh();
+                $testCase->paginaProcesso->navegarParaConsultarAndamentos();
+                $this->assertTrue($testCase->paginaConsultarAndamentos->contemTramiteProcessoRejeitado($unidadeDestino, $motivoRecusa));
+                return true;
+            }, PEN_WAIT_TIMEOUT);
+
         }
     }
 

--- a/tests/funcional/tests_sei4/RecebimentoRecusaJustificativaGrandeTest.php
+++ b/tests/funcional/tests_sei4/RecebimentoRecusaJustificativaGrandeTest.php
@@ -1,0 +1,118 @@
+<?php
+
+use \utilphp\util;
+
+class RecebimentoRecusaJustificativaGrandeTest extends CenarioBaseTestCase
+{
+
+    protected $destinatarioWs;
+    protected $servicoPEN;
+    public static $remetente;
+    public static $destinatario;    
+    public static $processoTeste;
+    public static $documentoTeste;
+    public static $protocoloTeste;
+
+
+    public function setUp(): void
+    {
+        parent::setup();
+
+        // Carregar contexto de testes e dados sobre certificado digital
+        $this->destinatarioWs = $this->definirContextoTeste(CONTEXTO_ORGAO_B);
+
+        // Instanciar objeto de teste utilizando o BeSimpleSoap
+        $localCertificado = $this->destinatarioWs['LOCALIZACAO_CERTIFICADO_DIGITAL'];
+        $senhaCertificado = $this->destinatarioWs['SENHA_CERTIFICADO_DIGITAL'];
+        $this->servicoPEN = $this->instanciarApiDeIntegracao($localCertificado, $senhaCertificado);
+    }
+
+    /**
+     * Teste de trâmite externo de processo com devolução para a mesma unidade de origem
+     *
+     * @group envio
+     *
+     * @return void
+     */
+    public function test_tramitar_processo_da_origem()
+    {
+
+        // Configuração do dados para teste do cenário
+        self::$remetente = $this->definirContextoTeste(CONTEXTO_ORGAO_A);
+        self::$destinatario = $this->definirContextoTeste(CONTEXTO_ORGAO_B);
+        self::$processoTeste = $this->gerarDadosProcessoTeste(self::$remetente);
+        self::$documentoTeste = $this->gerarDadosDocumentoInternoTeste(self::$remetente);
+
+        $this->realizarTramiteExternoSemvalidacaoNoRemetente(self::$processoTeste, self::$documentoTeste, self::$remetente, self::$destinatario);
+        self::$protocoloTeste = self::$processoTeste["PROTOCOLO"];
+
+        $bancoOrgaoA = new DatabaseUtils(CONTEXTO_ORGAO_A);
+        $id_tramite = $bancoOrgaoA->query("select max(id_tramite) as id_tramite from sei.md_pen_componente_digital where protocolo = ?", array(self::$protocoloTeste));
+        //recusa o tramite contendo justificativa grande
+        $this->recusarTramite($this->servicoPEN, $id_tramite[0]["id_tramite"]);        
+    }
+
+    /**
+     * Teste de verificação do correto recebimento do processo no destinatário
+     *
+     * @group verificacao_recebimento
+     *
+     * @depends test_tramitar_processo_da_origem
+     *
+     * @return void
+     */
+    public function test_verificar_destino_processo_para_devolucao()
+    {
+        // Configuração do dados para teste do cenário
+        self::$remetente = $this->definirContextoTeste(CONTEXTO_ORGAO_A);
+
+        $this->acessarSistema(self::$remetente['URL'], self::$remetente['SIGLA_UNIDADE'], self::$remetente['LOGIN'], self::$remetente['SENHA']);
+        $this->abrirProcesso(self::$protocoloTeste);
+        $this->assertTrue($this->paginaProcesso->processoAberto());
+
+        $unidade = mb_convert_encoding(self::$destinatario['NOME_UNIDADE'], "ISO-8859-1");
+        $this->validarRecibosTramite(sprintf("Trâmite externo do Processo %s para %s", self::$protocoloTeste, $unidade) , true, false);
+        $this->validarHistoricoTramite(self::$destinatario['NOME_UNIDADE'], true, false, true, sprintf("An exception occurred while executing 'INSERT INTO juntadas (numeracao_sequencial, movimento, ativo, vinculada, criado_em, atualizado_em, id, uuid, documentos_juntado_id, volumes_id, atividades_id, tarefas_id, comunicacoes_id, origem_dados_id, criado_por, atualizado_por) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)' with params [1, 'DOCUMENTO RECEBIDO VIA INTEGRA\u00c7\u00c3O COM O BARRAMENTO', 1, 0, '2021-12-02 14:21:48', '2021-12-02 14:21:48', 1317074776, '06ba31e8-75ad-4111-82d ..."));
+
+        //Verifica se os í­cones de alerta de recusa foram adicionados e se o processo continua aberto na unidade
+        $this->paginaBase->navegarParaControleProcesso();
+        $this->assertTrue($this->paginaControleProcesso->contemProcesso(self::$protocoloTeste));
+        $this->assertTrue($this->paginaControleProcesso->contemAlertaProcessoRecusado(self::$protocoloTeste));
+    }
+
+    private function recusarTramite($servicoPEN, $id_tramite)
+    {
+        $justificativa = "An exception occurred while executing 'INSERT INTO juntadas (numeracao_sequencial, movimento, ativo, vinculada, criado_em, atualizado_em, id, uuid, documentos_juntado_id, volumes_id, atividades_id, tarefas_id, comunicacoes_id, origem_dados_id, criado_por, atualizado_por) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)' with params [1, 'DOCUMENTO RECEBIDO VIA INTEGRA\u00c7\u00c3O COM O BARRAMENTO', 1, 0, '2021-12-02 14:21:48', '2021-12-02 14:21:48', 1317074776, '06ba31e8-75ad-4111-82dc-6f451f51825e', 1333864526, null, null, null, null, 3534979787, null, null]: ORA-00001: restrição exclusiva (SAPIENS.UNIQ_867686DHDKJ97876) violada";
+
+        $parametros = new stdClass();
+        $parametros->recusaDeTramite = new stdClass();
+        $parametros->recusaDeTramite->IDT = $id_tramite;
+        $parametros->recusaDeTramite->justificativa = utf8_encode($justificativa);
+        $parametros->recusaDeTramite->motivo = "99";
+        return $servicoPEN->recusarTramite($parametros);
+    }
+
+
+    private function instanciarApiDeIntegracao($localCertificado, $senhaCertificado)
+    {
+        $connectionTimeout = 600;
+        $options = array(
+            'soap_version' => SOAP_1_1
+            , 'local_cert' => $localCertificado
+            , 'passphrase' => $senhaCertificado
+            , 'resolve_wsdl_remote_includes' => true
+            , 'cache_wsdl'=> BeSimple\SoapCommon\Cache::TYPE_NONE
+            , 'connection_timeout' => $connectionTimeout
+            , CURLOPT_TIMEOUT => $connectionTimeout
+            , CURLOPT_CONNECTTIMEOUT => $connectionTimeout
+            , 'encoding' => 'UTF-8'
+            , 'attachment_type' => BeSimple\SoapCommon\Helper::ATTACHMENTS_TYPE_MTOM
+            , 'ssl' => array(
+                'allow_self_signed' => true,
+            ),
+        );
+
+        return new BeSimple\SoapClient\SoapClient(PEN_ENDERECO_WEBSERVICE, $options);
+
+    }
+}

--- a/tests/funcional/tests_sei4/TramiteProcessoContendoDocumentoMovidoSemAnexoTest.php
+++ b/tests/funcional/tests_sei4/TramiteProcessoContendoDocumentoMovidoSemAnexoTest.php
@@ -1,0 +1,246 @@
+<?php
+
+/**
+ * Testes de trâmite de processos contendo um documento movido sem anexo
+ *
+ * Este mesmo documento deve ser recebido e assinalado como cancelado no destinatário e
+ * a devolução do mesmo processo não deve ser impactado pela inserção de outros documentos
+ */
+class TramiteProcessoContendoDocumentoMovidoSemAnexoTest extends CenarioBaseTestCase
+{
+    public static $remetente;
+    public static $destinatario;
+    public static $processoTeste;
+    public static $documentoTeste1;
+    public static $documentoTeste2;
+    public static $documentoTeste3;
+    public static $documentoTeste4;
+    public static $protocoloTeste;
+
+    /**
+     * Teste inicial de trâmite de um processo contendo um documento movido
+     *
+     * @group envio
+     *
+     * @return void
+     */
+    public function test_tramitar_processo_contendo_documento_movido_sem_anexo()
+    {
+        self::$remetente = $this->definirContextoTeste(CONTEXTO_ORGAO_A);
+        self::$destinatario = $this->definirContextoTeste(CONTEXTO_ORGAO_B);
+
+        // Definição de dados de teste do processo principal
+        self::$processoTeste = $this->gerarDadosProcessoTeste(self::$remetente);
+        $processoSecundarioTeste = $this->gerarDadosProcessoTeste(self::$remetente);
+        self::$documentoTeste1 = $this->gerarDadosDocumentoExternoTeste(self::$remetente);
+        self::$documentoTeste2 = $this->gerarDadosDocumentoInternoTeste(self::$remetente);
+
+        // Acessar sistema do this->REMETENTE do processo
+        $this->acessarSistema(self::$remetente['URL'], self::$remetente['SIGLA_UNIDADE'], self::$remetente['LOGIN'], self::$remetente['SENHA']);
+
+        // Criar processo secundário para o qual o documento será movido
+        $protocoloSecundarioTeste = $this->cadastrarProcesso($processoSecundarioTeste);
+
+        // Cadastrar novo processo de teste e incluir documentos a ser movido
+        $this->paginaBase->navegarParaControleProcesso();
+        self::$protocoloTeste = $this->cadastrarProcesso(self::$processoTeste);
+        $this->cadastrarDocumentoExterno(self::$documentoTeste1, false);
+        $this->paginaDocumento->navegarParaMoverDocumento();
+        $this->paginaMoverDocumento->moverDocumentoParaProcesso($protocoloSecundarioTeste, "Motivo de teste");
+
+        // Cadastramento de documento adicional
+        $this->cadastrarDocumentoInterno(self::$documentoTeste2);
+        $this->assinarDocumento(self::$remetente['ORGAO'], self::$remetente['CARGO_ASSINATURA'], self::$remetente['SENHA']);
+
+        // Trâmitar Externamento processo para órgão/unidade destinatária
+        $this->tramitarProcessoExternamente(
+            self::$protocoloTeste,
+            self::$destinatario['REP_ESTRUTURAS'],
+            self::$destinatario['NOME_UNIDADE'],
+            self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'],
+            false
+        );
+    }
+
+
+    /**
+     * Teste de verificação do correto envio do processo no sistema remetente
+     *
+     * @group verificacao_envio
+     *
+     * @depends test_tramitar_processo_contendo_documento_movido_sem_anexo
+     *
+     * @return void
+     */
+    public function test_verificar_origem_processo()
+    {
+        $orgaosDiferentes = self::$remetente['URL'] != self::$destinatario['URL'];
+        $this->acessarSistema(self::$remetente['URL'], self::$remetente['SIGLA_UNIDADE'], self::$remetente['LOGIN'], self::$remetente['SENHA']);
+        $this->abrirProcesso(self::$protocoloTeste);
+
+        $this->waitUntil(function ($testCase) use (&$orgaosDiferentes) {
+            sleep(5);
+            $testCase->refresh();
+            $paginaProcesso = new PaginaProcesso($testCase);
+            $testCase->assertStringNotContainsString(utf8_encode("Processo em trâmite externo para "), $paginaProcesso->informacao());
+            $testCase->assertFalse($paginaProcesso->processoAberto());
+            $testCase->assertEquals($orgaosDiferentes, $paginaProcesso->processoBloqueado());
+            return true;
+        }, PEN_WAIT_TIMEOUT);
+
+        $unidade = mb_convert_encoding(self::$destinatario['NOME_UNIDADE'], "ISO-8859-1");
+        $mensagemRecibo = sprintf("Trâmite externo do Processo %s para %s", self::$protocoloTeste, $unidade);
+        $this->validarRecibosTramite($mensagemRecibo, true, true);
+        $this->validarHistoricoTramite(self::$destinatario['NOME_UNIDADE'], true, true);
+        $this->validarProcessosTramitados(self::$protocoloTeste, $orgaosDiferentes);
+    }
+
+    /**
+     * Teste de verificação do correto recebimento do processo com documento movido no destinatário
+     *
+     * @group verificacao_recebimento
+     *
+     * @depends test_verificar_origem_processo
+     *
+     * @return void
+     */
+    public function test_verificar_destino_processo_com_documento_movido_sem_anexo()
+    {
+        $strProtocoloTeste = self::$protocoloTeste;
+        $orgaosDiferentes = self::$remetente['URL'] != self::$destinatario['URL'];
+
+        $this->acessarSistema(self::$destinatario['URL'], self::$destinatario['SIGLA_UNIDADE'], self::$destinatario['LOGIN'], self::$destinatario['SENHA']);
+        $this->abrirProcesso(self::$protocoloTeste);
+
+        $strTipoProcesso = utf8_encode("Tipo de processo no órgão de origem: ");
+        $strTipoProcesso .= self::$processoTeste['TIPO_PROCESSO'];
+        $strObservacoes = $orgaosDiferentes ? $strTipoProcesso : null;
+        $this->validarDadosProcesso(
+            self::$processoTeste['DESCRICAO'],
+            self::$processoTeste['RESTRICAO'],
+            $strObservacoes,
+            array(self::$processoTeste['INTERESSADOS'])
+        );
+
+        $this->validarRecibosTramite("Recebimento do Processo $strProtocoloTeste", false, true);
+
+        // Validação dos dados do processo principal
+        $listaDocumentosProcessoPrincipal = $this->paginaProcesso->listarDocumentos();
+        $this->assertEquals(2, count($listaDocumentosProcessoPrincipal));
+        $this->validarDocumentoCancelado($listaDocumentosProcessoPrincipal[0]);
+        $this->validarDadosDocumento($listaDocumentosProcessoPrincipal[1], self::$documentoTeste2, self::$destinatario);
+    }
+
+
+    /**
+     * Teste de trâmite externo de processo realizando a devolução para a mesma unidade de origem contendo
+     * mais dois documentos, sendo um deles movido
+     *
+     * @group envio
+     *
+     * @depends test_verificar_destino_processo_com_documento_movido_sem_anexo
+     *
+     * @return void
+     */
+    public function test_devolucao_processo_para_origem_com_novo_documento_movido_sem_anexo()
+    {
+        self::$remetente = $this->definirContextoTeste(CONTEXTO_ORGAO_B);
+        self::$destinatario = $this->definirContextoTeste(CONTEXTO_ORGAO_A);
+
+        // Criar processo secundário para o qual o novo documento será movido
+        $processoSecundarioTeste = $this->gerarDadosProcessoTeste(self::$remetente);
+        self::$documentoTeste3 = $this->gerarDadosDocumentoExternoTeste(self::$remetente);
+        self::$documentoTeste4 = $this->gerarDadosDocumentoInternoTeste(self::$remetente);
+
+        // Acessar sistema do this->REMETENTE do processo
+        $this->acessarSistema(self::$remetente['URL'], self::$remetente['SIGLA_UNIDADE'], self::$remetente['LOGIN'], self::$remetente['SENHA']);
+
+        $protocoloSecundarioTeste = $this->cadastrarProcesso($processoSecundarioTeste);
+
+        // Incluir novos documentos ao processo para ser movido
+        $this->abrirProcesso(self::$protocoloTeste);
+        $this->cadastrarDocumentoExterno(self::$documentoTeste3, false);
+        $this->paginaDocumento->navegarParaMoverDocumento();
+        $this->paginaMoverDocumento->moverDocumentoParaProcesso($protocoloSecundarioTeste, "Motivo de teste");
+
+        // Cadastramento de documento adicional
+        $this->cadastrarDocumentoInterno(self::$documentoTeste4);
+        $this->assinarDocumento(self::$remetente['ORGAO'], self::$remetente['CARGO_ASSINATURA'], self::$remetente['SENHA']);
+
+        // Trâmitar Externamento processo para órgão/unidade destinatária
+        $this->tramitarProcessoExternamente(
+            self::$protocoloTeste,
+            self::$destinatario['REP_ESTRUTURAS'],
+            self::$destinatario['NOME_UNIDADE'],
+            self::$destinatario['SIGLA_UNIDADE_HIERARQUIA'],
+            false
+        );
+    }
+
+
+    /**
+     * Teste de verificação do correto envio do processo no sistema remetente
+     *
+     * @group verificacao_envio
+     *
+     * @depends test_devolucao_processo_para_origem_com_novo_documento_movido_sem_anexo
+     *
+     * @return void
+     */
+    public function test_verificar_devolucao_origem_processo()
+    {
+        $orgaosDiferentes = self::$remetente['URL'] != self::$destinatario['URL'];
+
+        $this->acessarSistema(self::$remetente['URL'], self::$remetente['SIGLA_UNIDADE'], self::$remetente['LOGIN'], self::$remetente['SENHA']);
+        $this->abrirProcesso(self::$protocoloTeste);
+
+        $this->waitUntil(function ($testCase) use (&$orgaosDiferentes) {
+            sleep(5);
+            $testCase->refresh();
+            $paginaProcesso = new PaginaProcesso($testCase);
+            $testCase->assertStringNotContainsString(utf8_encode("Processo em trâmite externo para "), $paginaProcesso->informacao());
+            $testCase->assertFalse($paginaProcesso->processoAberto());
+            $testCase->assertEquals($orgaosDiferentes, $paginaProcesso->processoBloqueado());
+            return true;
+        }, PEN_WAIT_TIMEOUT);
+
+        $unidade = mb_convert_encoding(self::$destinatario['NOME_UNIDADE'], "ISO-8859-1");
+        $mensagemRecibo = sprintf("Trâmite externo do Processo %s para %s", self::$protocoloTeste, $unidade);
+        $this->validarRecibosTramite($mensagemRecibo, true, true);
+        $this->validarHistoricoTramite(self::$destinatario['NOME_UNIDADE'], true, true);
+        $this->validarProcessosTramitados(self::$protocoloTeste, $orgaosDiferentes);
+    }
+
+    /**
+     * Teste de verificação da correta devolução do processo no destinatário
+     *
+     * @group verificacao_recebimento
+     *
+     * @depends test_verificar_devolucao_origem_processo
+     *
+     * @return void
+     */
+    public function test_verificar_devolucao_destino_processo_com_dois_documentos_movidos_sem_anexo()
+    {
+        $strProtocoloTeste = self::$protocoloTeste;
+        $this->acessarSistema(self::$destinatario['URL'], self::$destinatario['SIGLA_UNIDADE'], self::$destinatario['LOGIN'], self::$destinatario['SENHA']);
+        $this->abrirProcesso(self::$protocoloTeste);
+
+        $this->validarDadosProcesso(
+            self::$processoTeste['DESCRICAO'],
+            self::$processoTeste['RESTRICAO'],
+            self::$processoTeste['OBSERVACOES'],
+            array(self::$processoTeste['INTERESSADOS'])
+        );
+
+        $this->validarRecibosTramite("Recebimento do Processo $strProtocoloTeste", false, true);
+
+        // Validação dos dados do processo principal
+        $listaDocumentosProcesso = $this->paginaProcesso->listarDocumentos();
+        $this->assertEquals(4, count($listaDocumentosProcesso));
+        $this->validarDocumentoMovido($listaDocumentosProcesso[0]);
+        $this->validarDadosDocumento($listaDocumentosProcesso[1], self::$documentoTeste2, self::$destinatario);
+        $this->validarDocumentoCancelado($listaDocumentosProcesso[2]);
+        $this->validarDadosDocumento($listaDocumentosProcesso[3], self::$documentoTeste4, self::$destinatario);
+    }
+}


### PR DESCRIPTION
Correções de erros no tramite de processo contendo documento movidos sem anexo. Correção na gravação do motivo da recusa superior a 500 caracteres. E pequenos ajustes na funcionalidade de tramitação em lote.