### PR TITLE
test: adiciona teste de compatibilidade de versão do PHP 5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,18 @@
+{
+    "config": {
+      "platform": {
+          "php": "7.4.28"
+      },
+      "allow-plugins": {
+        "composer/package-versions-deprecated": true,
+        "dealerdirect/phpcodesniffer-composer-installer": true
+      }
+    },  
+    "require-dev": {
+      "friendsofphp/php-cs-fixer": "^3.6",
+      "squizlabs/php_codesniffer": "^3.6",
+      "phpcompatibility/php-compatibility": "*",
+      "dealerdirect/phpcodesniffer-composer-installer": "^0.7.2"
+    },
+  "prefer-stable" : true
+  }


### PR DESCRIPTION
Para testes automatizados do compatibilidade da versão do PHP 5.4 enquanto houver suporte. Para testar use o comando 

`./vendor/bin/phpcs -p ./src --standard=PHPCompatibility --runtime-set testVersion 5.4
`

Closes: #157